### PR TITLE
resolve Fermi issues for certain spin-polarized systems with QE 6.2

### DIFF
--- a/src/defs/read_new_QE_output_xml_parse.py
+++ b/src/defs/read_new_QE_output_xml_parse.py
@@ -71,13 +71,22 @@ def read_new_QE_output_xml(fpath,verbose,non_ortho):
                 k3=int(elem.findall(".//monkhorst_pack")[0].attrib['k3'])
                 if rank == 0 and verbose: print('Monkhorst&Pack grid',nk1,nk2,nk3,k1,k2,k3)
                
-	        # Get hightest occupied level for non-metals
+	        # Get hightest occupied level or fermi energy
                 try:
-                    hstoccu = float(elem.findall("band_structure/highestOccupiedLevel")[0].text)*Hatree2eV
+                    Efermi = float(elem.findall("band_structure/highestOccupiedLevel")[0].text)*Hatree2eV
                 except:
     		    pass
+		try:
+		    Efermi = float(elem.findall("band_structure/fermi_energym")[0].text)*Hatree2eV
+		except:
+		    pass
+		try:
+		    aux = elem.findall("band_structure/two_fermi_energies")[0].text.split()
+		    Efermi = float(np.amax(np.array(aux,dtype='float32')))*Hatree2eV
+		except:
+		    pass
 
-               # Atomic Positions
+                # Atomic Positions
                 natoms=int(float(elem.findall("atomic_structure")[0].attrib['nat']))
                 tau = np.zeros((natoms,3),dtype=float)
                 for n in xrange(natoms):
@@ -113,17 +122,8 @@ def read_new_QE_output_xml(fpath,verbose,non_ortho):
 
             aux    = elem.findall("UNITS_FOR_ENERGY")[0].attrib['UNITS']
 
-	    # Get Fermi energy(Hightest occupied level for non-metals)
-            Efermi = float(elem.findall("FERMI_ENERGY")[0].text.split()[0])*Ry2eV
-            try:
-		Efermi = hstoccu 
-	    except:
-		pass
-            if rank == 0 and verbose: print('Fermi energy: {0:f} eV '.format(Efermi))
-
             nawf   =int(elem.findall("NUMBER_OF_ATOMIC_WFC")[0].text.split()[0])
             if rank == 0 and verbose: print('Number of atomic wavefunctions: {0:d}'.format(nawf))
-
 
             elem.clear()
 


### PR DESCRIPTION
For spin-polarized systems with two spin channels and fixed occupation, use the higher Fermi energy in the data_file_schema.xml