### PR TITLE
shift datatype fixed

### DIFF
--- a/src/defs/read_inputfile_xml_parse.py
+++ b/src/defs/read_inputfile_xml_parse.py
@@ -179,7 +179,7 @@ def read_inputfile_xml ( fpath, inputfile ):
     fpath = read_attribute(aroot, fpath, 'fpath', 'string')
     shift = read_attribute(aroot, shift, 'shift', 'string')
     try:
-        shift = read_attribute(aroot, shift, 'shift', 'string')
+        shift = read_attribute(aroot, shift, 'shift', 'decimal')
     except:
         pass
     out_vals = read_attribute(aroot, out_vals, 'out_vals', 'string')


### PR DESCRIPTION
shift was always treated as string in the xml inputfile, now as decimal if a numerical value is presented