### PR TITLE
Implementation of inverse pariticipation ratio (IPR)

### DIFF
--- a/src/PAOFLOW.py
+++ b/src/PAOFLOW.py
@@ -1399,3 +1399,41 @@ mo    '''
 
 
     self.report_module_time('Weyl Search')
+
+  def ipr(self, fname='ipr'):
+    '''
+    Compute the inverse partiticipation ratio (IPR) from PAO eigenstates
+
+                 \sum_n |v_nk|^4
+    IPR_nk = -----------------------
+              ( \sum_n |v_nk|^2 )^2
+
+    where n is the band index and k the k-point
+
+    The final shape is (nspin,nkpts,nbands,3),
+    where the last axis gives: 0 as the k-point coordinate,
+                               1 the band energy, and
+                               2 the inverse partition ratio
+
+    The result in saved to a ipr.npy file.
+    To open the file one should use:
+    `ipr = np.load('ipr.npy')`
+
+    '''
+
+    from .defs.do_ipr import inverse_participation_ratio
+    from os.path import join
+
+    arry, attr = self.data_controller.data_dicts()
+
+    try:
+      arry['ipr'] = inverse_participation_ratio(self.data_controller)
+      np.save(join(attr['opath'],fname+'.npy'),arry['ipr'])
+
+    except Exception as e:
+      self.report_exception('ipr')
+      if attr['abort_on_exception']:
+        raise e
+
+    self.report_module_time('Inverse Participation Ratio (IPR)')
+

--- a/src/defs/do_ipr.py
+++ b/src/defs/do_ipr.py
@@ -1,0 +1,52 @@
+#
+# PAOFLOW
+#
+# Utility to construct and operate on Hamiltonians from the Projections of DFT wfc on Atomic Orbital bases (PAO)
+#
+# Copyright (C) 2016-2018 ERMES group (http://ermes.unt.edu, mbn@unt.edu)
+#
+# Reference:
+# M. Buongiorno Nardelli, F. T. Cerasoli, M. Costa, S Curtarolo,R. De Gennaro, M. Fornari, L. Liyanage, A. Supka and H. Wang,
+# PAOFLOW: A utility to construct and operate on ab initio Hamiltonians from the Projections of electronic wavefunctions on
+# Atomic Orbital bases, including characterization of topological materials, Comp. Mat. Sci. vol. 143, 462 (2018).
+#
+# This file is distributed under the terms of the
+# GNU General Public License. See the file `License'
+# in the root directory of the present distribution,
+# or http://www.gnu.org/copyleft/gpl.txt .
+#
+
+import numpy as np
+
+def inverse_participation_ratio (data_controller):
+
+  arry,attr = data_controller.data_dicts()
+
+  nbands = attr['bnd']
+
+  if 'Hksp' in arry:
+    kpts = arry['kpnts']
+  else:
+    kpts = arry['kq'].T
+
+  nkpts = kpts.shape[0]
+
+  nspin = attr['nspin']
+
+  ipr = np.zeros((nspin,nkpts,nbands,3),dtype=object)
+
+  for ispin in range(nspin):
+    for ikpt in range(nkpts):
+      for iband in range(nbands):
+
+        vk = arry['v_k'][ikpt,:,iband,ispin]
+        ek = arry['E_k'][ikpt,iband,ispin]
+
+        vk_abs = np.abs(vk)
+
+        ipr[ispin,ikpt,iband,0] = kpts[ikpt]
+        ipr[ispin,ikpt,iband,1] = ek
+        ipr[ispin,ikpt,iband,2] = np.sum(vk_abs**4) / ( np.sum(vk_abs**2)**2 )
+
+  return ipr
+

--- a/src/defs/module_prerequisites.py
+++ b/src/defs/module_prerequisites.py
@@ -17,6 +17,7 @@ module_pre_reqs = { 'add_external_fields'      : ['projectability'],\
                     'fermi_surface'            : ['pao_eigh'],\
                     'spin_texture'             : ['pao_eigh'],
                     'gradient_and_momenta'     : ['pao_eigh'],\
+                    'ipr'                      : ['pao_eigh'],\
                     'real_space_wfc'           : ['gradient_and_momenta', 'atomic_orbitals'], \
                     'adaptive_smearing'        : ['gradient_and_momenta'],\
                     'anomalous_Hall'           : ['gradient_and_momenta'],\


### PR DESCRIPTION
Implementation uses the following formula:

                 \sum_n |v_nk|^4
    IPR_nk = -----------------------
              ( \sum_n |v_nk|^2 )^2
              
where n is the band index and k the k-point

This pull request comprehends:
- added ipr to PAOFLOW.py
- adding do_ipr.py to defs folder
- added ipr to module_prerequisites