### PR TITLE
Pin scipy version to one compatible with PAOFLOW

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='PAOFLOW',
       long_description_content_type="text/markdown",
       packages=['PAOFLOW', 'PAOFLOW.defs'],
       package_dir={'PAOFLOW':'src'},
-      install_requires=['numpy','scipy'],
+      install_requires=['numpy','scipy~=1.9.0'],
       extras_require={'weyl_search':['z2pack', 'tbmodels']},
       python_requires='>=3.6'
 )


### PR DESCRIPTION
The version of scipy being installed using setup.py has been pinned to ~=1.9.0. 

scipy ~=1.14.0 raises `AttributeError: module 'scipy.integrate' has no attribute 'simps'` since simps was renamed to simpson in these versions. See https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.simpson.html

scipy > 1.9 raises `TypeError: array type complex256 is unsupported in linalg`. Some discussion on this appears here
https://github.com/scipy/scipy/issues/18250
