### PR TITLE
Include ACBN0 in pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,10 @@ minimum_pre_commit_version: "2.20.0"
 default_language_version:
   python: python3
 
-# TODO: remove this exclusion after discussing with ACBNO maintainers
 exclude: |
   (?x)^(?:
     BASIS/|
     examples
-    #src/PAOFLOW/ACBN0\.py$
   )
 
 repos:


### PR DESCRIPTION
This PR reinstates pre-commit hooks for ACBN0 modules. They were being ignored for ACBN0 because several Ruff tests were failing and couldn't be fixed manually without understanding the code logic. However, @hzr-piggy's latest changes have addressed the issue. 