### PR TITLE
Fix gitignore and init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,4 +119,4 @@ pseudo/
 **/*.xml
 
 # MAC files
-.DS_store*
+.DS_*

--- a/src/PAOFLOW/__init__.py
+++ b/src/PAOFLOW/__init__.py
@@ -2,4 +2,4 @@
 Utility to construct and operate on Hamiltonians from the Projections of DFT wfc on Atomic Orbital bases (PAO).
 """
 
-__version__ = '2.2.2'
+__version__ = '2.9.0'


### PR DESCRIPTION
## Base branch (IMPORTANT)

This repo uses **develop → main** promotion.

✅ Your PR must target: **base = `develop`**

If your PR is targeting **`main`**, fix it now:
1) In the PR header, find: `base: main ← compare: <your-branch>`
2) Click **Edit**
3) Change **base** from `main` to **`develop`**
4) Click **Update**

PRs targeting `main` will be blocked/closed unless they are **develop → main** release PRs.
