### PR TITLE
Reintroduce example09 to workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,7 @@ jobs:
           - example06
           - example07
           - example08
+          - example09
           - example10
           - example11
           - example14

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev, weyl_search]"
           pip install matplotlib
 
       - name: Verify MPI

--- a/tests/integration/qe/compare.py
+++ b/tests/integration/qe/compare.py
@@ -9,7 +9,6 @@ import numpy as np
 
 SKIP_COMPARE_PATTERNS = {
     'hamiltonian.dat',
-    'weyl_points.dat',
     'Omega_z_xy.dat',
     'effmass*',
 }

--- a/tests/integration/qe/example09/main.py
+++ b/tests/integration/qe/example09/main.py
@@ -1,0 +1,15 @@
+from PAOFLOW import PAOFLOW
+
+
+def main():
+    paoflow = PAOFLOW.PAOFLOW(savedir='MoP2.save', verbose=False, outputdir='./output')
+    paoflow.read_atomic_proj_QE()
+    paoflow.projectability(pthr=0.95)
+    paoflow.pao_hamiltonian(symmetrize=True, thresh=1.0e-10, max_iter=2)
+    paoflow.write_Hamiltonian()
+    paoflow.find_weyl_points(search_grid=[2, 2, 2])
+    paoflow.finish_execution()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/qe/example09/main.py
+++ b/tests/integration/qe/example09/main.py
@@ -5,9 +5,9 @@ def main():
     paoflow = PAOFLOW.PAOFLOW(savedir='MoP2.save', verbose=False, outputdir='./output')
     paoflow.read_atomic_proj_QE()
     paoflow.projectability(pthr=0.95)
-    paoflow.pao_hamiltonian(symmetrize=True, thresh=1.0e-10, max_iter=2)
+    paoflow.pao_hamiltonian(symmetrize=True, thresh=1.0e-10, max_iter=64)
     paoflow.write_Hamiltonian()
-    paoflow.find_weyl_points(search_grid=[2, 2, 2])
+    paoflow.find_weyl_points(search_grid=[8, 8, 8])
     paoflow.finish_execution()
 
 


### PR DESCRIPTION
Example09 was ignored by the CI workflow due to a bug in generating output files for it. Since the bug has been fixed in PR #132, this PR reintroduces example09 into the integration tests workflow