### PR TITLE
removed 'workflows'

### DIFF
--- a/.github/workflows/pr-merge-teams-notification.yml
+++ b/.github/workflows/pr-merge-teams-notification.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  workflows: write
 
 jobs:
   notify-teams:


### PR DESCRIPTION
After making the correction I got

```
solaire@system76-pc ~/git/marcobn/PAOFLOW
bash$ gh workflow run   .github/workflows/pr-merge-teams-notification.yml   --ref develop-jonred
✓ Created workflow_dispatch event for pr-merge-teams-notification.yml at develop-jonred

To see runs for this workflow, try: gh run list --workflow=pr-merge-teams-notification.yml
```

which also generated a teams channel notification.  