### PR TITLE
Bug fix: Documentation

### DIFF
--- a/docs/internals/api-reference.md
+++ b/docs/internals/api-reference.md
@@ -3,26 +3,8 @@
 This section contains the full Python API generated automatically from the source code.
 
 ```{toctree}
+:glob:
 :maxdepth: 2
 
-../api/autoapi/PAOFLOW/ACBN0/index
-../api/autoapi/PAOFLOW/DataController/index
-../api/autoapi/PAOFLOW/ErrorHandler/index
-../api/autoapi/PAOFLOW/GPAO/index
-../api/autoapi/PAOFLOW/PAOFLOW/index
-../api/autoapi/PAOFLOW/basis_gen/index
-../api/autoapi/PAOFLOW/boltzmann/index
-../api/autoapi/PAOFLOW/gen/index
-../api/autoapi/PAOFLOW/graphics/index
-../api/autoapi/PAOFLOW/hamiltonian/index
-../api/autoapi/PAOFLOW/inputs/index
-../api/autoapi/PAOFLOW/models/index
-../api/autoapi/PAOFLOW/projection/index
-../api/autoapi/PAOFLOW/pyskeaf/index
-../api/autoapi/PAOFLOW/response/index
-../api/autoapi/PAOFLOW/spectrum/index
-../api/autoapi/PAOFLOW/topology/index
-../api/autoapi/PAOFLOW/transport/index
-../api/autoapi/PAOFLOW/utils/index
-../api/autoapi/PAOFLOW/writers/index
+../api/autoapi/PAOFLOW/*/index
 ```


### PR DESCRIPTION
This PR fixes a bug where all new modules were not automatically detected when building the Reference API for ReadTheDocs. 

The automatic detection was configured in `conf.py` but the `api-reference.md`  manually configured each module. This has been fixed. 